### PR TITLE
Fix Funcionario manager

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,16 @@
 from django.test import TestCase
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from .models import Funcionario
+
+
+class FuncionarioManagerTests(TestCase):
+    def test_create_user_creates_related_user(self):
+        funcionario = Funcionario.objects.create_user(
+            matricula="123", nome="Teste", senha="pwd12345"
+        )
+
+        self.assertEqual(funcionario.matricula, "123")
+        self.assertEqual(funcionario.user.username, "123")
+        self.assertEqual(funcionario.user.first_name, "Teste")
+        self.assertTrue(funcionario.user.check_password("pwd12345"))


### PR DESCRIPTION
## Summary
- fix FuncionarioManager.create_user to properly create User
- register the manager on Funcionario
- add unit test covering the manager

## Testing
- `python -m py_compile core/models.py`
- `python -m py_compile core/tests.py`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68545ea01a548320a783a6d63917c97a