### PR TITLE
Add login API test and enable pytest

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,6 +1,12 @@
-from django.test import TestCase
+import os
+import django
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+django.setup()
+
+from django.test import TestCase, Client
 from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import AccessToken
 from .models import Funcionario
 
 
@@ -14,3 +20,23 @@ class FuncionarioManagerTests(TestCase):
         self.assertEqual(funcionario.user.username, "123")
         self.assertEqual(funcionario.user.first_name, "Teste")
         self.assertTrue(funcionario.user.check_password("pwd12345"))
+
+
+class LoginAPITests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.funcionario = Funcionario.objects.create_user(
+            matricula="321", nome="Login", senha="loginpwd"
+        )
+
+    def test_login_returns_jwt_token(self):
+        response = self.client.post(
+            "/api/login/",
+            {"matricula": "321", "senha": "loginpwd"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("access", data)
+        # validate that the token can be decoded
+        AccessToken(data["access"])

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = app.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
## Summary
- add pytest configuration for Django
- test login endpoint returns a valid JWT token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854658697088320b423f7e13d294b72