### PR TITLE
Fix script block closure in terminal.html

### DIFF
--- a/core/templates/terminal.html
+++ b/core/templates/terminal.html
@@ -1121,7 +1121,7 @@ document.addEventListener('DOMContentLoaded', async function() {
                             hideLoading();
                         }
                     };
-        });
+        }
 
     // Submit do formulário
     if (atividadesFormIniciar) {
@@ -1243,5 +1243,6 @@ function getElapsedTime() {
     if (!appState.startTime) return 0;
     return Math.floor((Date.now() - appState.startTime.getTime()) / 1000); // segundos
 }
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- close `finalizarSessaoBtn` block correctly
- add missing closing for `DOMContentLoaded` handler in `terminal.html`

## Testing
- `pytest -q` *(fails: OperationalError: no such table: auth_user)*

------
https://chatgpt.com/codex/tasks/task_e_6854c65f04708320952e815f8c6d99c1